### PR TITLE
Tone down the red to improve contrast

### DIFF
--- a/index.css
+++ b/index.css
@@ -76,7 +76,7 @@ pre {
 	line-height: 2.5;
 }
 .match {
-	background-color: red;
+	background-color: #900;
 }
 .hljs-tag {
 	transition: background-color .4s;


### PR DESCRIPTION
Pure red is too bright to be used as a background color.